### PR TITLE
Pytest compatibility fix for initial main test suite template

### DIFF
--- a/project_cli/templates.py
+++ b/project_cli/templates.py
@@ -81,7 +81,7 @@ def get_context():
 
 def get_main_test_suite(name, runnable):
     result = '"""Contains a test suite for basic tests."""' + BR\
-             + "import context" + BR\
+             + "import tests.context" + BR\
              + "import unittest" + BR
     if runnable:
         result += "from " + name + ".__main__ import main" + BR

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.rst', 'r') as fh:
     long_description = fh.read()
 
 setup(name='project_cli',
-      version='0.2.1',
+      version='0.2.2',
       author='Ramon Hagenaars',
       description='A commandline interface for creating project structures',
       long_description=long_description,


### PR DESCRIPTION
Add 'tests' module name prefix to the context import in the initial test suite template.

This resolves an import bug when trying to run unit tests with pytest, which lacks the import modification mechanics of unittest.